### PR TITLE
Datastore query (and then some)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +301,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,7 +347,7 @@ checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -605,6 +687,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -1057,6 +1145,7 @@ dependencies = [
  "base64 0.22.1",
  "bincode",
  "chrono",
+ "clap 4.5.4",
  "criterion",
  "prost",
  "prost-build",
@@ -1189,6 +1278,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1422,6 +1517,12 @@ name = "unicode-width"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ chrono = "0.4"
 bincode = "1.3"   
 rmp-serde = "0.15"
 serde_json = "1.0"
+clap = "4.5"
 
 [build-dependencies]
 tonic-build = "0.11"

--- a/proto/datastore.proto
+++ b/proto/datastore.proto
@@ -39,7 +39,7 @@ message SetResponse {
 }
 
 message GetOptions {
-    int64 history_count = 1;
+    optional int64 history_count = 1;
 }
 
 message QueryRequest {

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,7 @@ use tonic::Request;
 
 use rmp_serde::decode::from_read_ref;
 use serde_json::{json, to_string, to_string_pretty, Value};
+use clap::{Arg, Command};
 
 use datastore::datastore_client::DatastoreClient;
 use datastore::{GetRequest, QueryRequest, SetRequest};
@@ -12,6 +13,9 @@ use base64::{engine::general_purpose, Engine as _};
 pub mod datastore {
     tonic::include_proto!("datastore");
 }
+
+const DEFAULT_HOST: &str = "127.0.0.1";
+const DEFAULT_PORT: &str = "7777";
 
 async fn get(
     client: &mut DatastoreClient<Channel>,
@@ -71,13 +75,13 @@ async fn set(
 async fn query(
     client: &mut DatastoreClient<Channel>,
     key: String,
+    history_count: Option<i64>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let request = QueryRequest {
-        key,
-        options: Some(datastore::GetOptions {
-            history_count: 0, // TODO: make this dynamic
-        }),
-    };
+    let options = history_count.map(|count| datastore::GetOptions {
+        history_count: Some(count),
+    });
+
+    let request = QueryRequest {key, options};
     let response = client.query(Request::new(request)).await?;
 
     let items = response.into_inner().items;
@@ -108,35 +112,52 @@ async fn query(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut args: Vec<String> = std::env::args().collect();
-    args.remove(0);
+    let cmd = Command::new("rs-datastore client")
+        .version("0.1.0")
+        .author("Sr. Rust Developer")
+        .arg_required_else_help(true)
+        .subcommand_required(true)
+        .subcommand(Command::new("get")
+            .about("gets a value for a key")
+            .arg(Arg::new("key").required(true)))
+        .subcommand(Command::new("set")
+            .about("sets a value for a key with optional ttl")
+            .arg(Arg::new("key").required(true))
+            .arg(Arg::new("value").required(true))
+            .arg(Arg::new("ttl").required(false).value_parser(clap::value_parser!(i64))))
+        .subcommand(Command::new("query")
+            .about("queries a key with optional history count")
+            .arg(Arg::new("key").required(true))
+            .arg(Arg::new("history_count").required(false).value_parser(clap::value_parser!(i64))))
+        .get_matches();
 
-    if args.is_empty() || args.len() < 2 {
-        println!("Usage: client <command> <key> [value] [ttl]");
-        return Ok(());
-    }
+    // Retrieve host and port from environment or use default values
+    let host = std::env::var("REMOTE_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string());
+    let port = std::env::var("REMOTE_PORT").unwrap_or_else(|_| DEFAULT_PORT.to_string());
+    let endpoint = format!("http://{}:{}", host, port);
 
-    let command = &args[0];
-    let keys = args[1].clone();
-    let mut client = DatastoreClient::connect("http://127.0.0.1:7777").await?;
+    let mut client = DatastoreClient::connect(endpoint).await?;
 
-    match command.as_str() {
-        "get" => {
-            get(&mut client, keys).await?;
-        }
-        "set" if args.len() > 2 => {
-            let value = args[2].as_bytes().to_vec();
-            let ttl = if args.len() > 3 {
-                args[3].parse::<i64>().unwrap_or(0) // Attempt to parse TTL if provided
-            } else {
-                0 // Default TTL if not provided
-            };
-            set(&mut client, keys, value, ttl).await?;
-        }
-        "query" => {
-            query(&mut client, keys).await?;
-        }
-        _ => println!("invalid command"),
+    match cmd.subcommand() {
+        Some(("get", sub_matches)) => {
+            let key = sub_matches.get_one::<String>("key").unwrap();
+            get(&mut client, key.to_string()).await?;
+        },
+        Some(("set", sub_matches)) => {
+            let key = sub_matches.get_one::<String>("key").unwrap();
+            let value = sub_matches.get_one::<String>("value").unwrap().as_bytes().to_vec();
+            let ttl = sub_matches.get_one::<String>("ttl")
+                        .and_then(|v| v.parse::<i64>().ok())
+                        .unwrap_or(0);
+            set(&mut client, key.to_string(), value, ttl).await?;
+        },
+        Some(("query", sub_matches)) => {
+            let key = sub_matches.get_one::<String>("key").unwrap();
+            let history_count = sub_matches.get_one::<String>("history_count")
+                                  .and_then(|v| v.parse::<i64>().ok());
+            query(&mut client, key.to_string(), history_count).await?;
+        },
+        _ => unreachable!(),
     }
 
     Ok(())

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,9 @@
 use tonic::transport::Channel;
 use tonic::Request;
 
+use clap::{Arg, ArgAction, Command};
 use rmp_serde::decode::from_read_ref;
 use serde_json::{json, to_string, to_string_pretty, Value};
-use clap::{Arg, Command};
 
 use datastore::datastore_client::DatastoreClient;
 use datastore::{GetRequest, QueryRequest, SetRequest};
@@ -20,26 +20,31 @@ const DEFAULT_PORT: &str = "7777";
 async fn get(
     client: &mut DatastoreClient<Channel>,
     key: String,
+    raw: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let request = GetRequest { key: key.clone() };
     let response = client.get(Request::new(request)).await?;
     let item = response.into_inner();
 
     if let Some(item) = item.item {
-        // deserialize messagepack into serde_json::Value
-        match from_read_ref::<_, Value>(&item.value) {
-            Ok(value) => {
-                if let Ok(json_str) = to_string_pretty(&value) {
-                    println!("{}", json_str);
-                } else {
-                    println!("Error formatting JSON");
+        if raw {
+            println!("{}", general_purpose::STANDARD.encode(&item.value));
+        } else {
+            // deserialize messagepack into serde_json::Value
+            match from_read_ref::<_, Value>(&item.value) {
+                Ok(value) => {
+                    if let Ok(json_str) = to_string_pretty(&value) {
+                        println!("{}", json_str);
+                    } else {
+                        println!("Error formatting JSON");
+                    }
                 }
-            }
-            Err(e) => {
-                println!(
-                    "[key: {}] Failed to deserialize MessagePack data: {:?}",
-                    item.key, e
-                );
+                Err(e) => {
+                    println!(
+                        "[key: {}] Failed to deserialize MessagePack data: {:?}",
+                        item.key, e
+                    );
+                }
             }
         }
     } else {
@@ -76,28 +81,36 @@ async fn query(
     client: &mut DatastoreClient<Channel>,
     key: String,
     history_count: Option<i64>,
+    raw: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let options = history_count.map(|count| datastore::GetOptions {
         history_count: Some(count),
     });
 
-    let request = QueryRequest {key, options};
+    let request = QueryRequest { key, options };
     let response = client.query(Request::new(request)).await?;
 
     let items = response.into_inner().items;
     let mut results = Vec::new();
 
     for item in items {
-        // deserialize messagepack into serde_json::Value
-        let value = match from_read_ref::<_, Value>(&item.value) {
-            Ok(value) => value,
-            Err(_) => json!({"error": "Failed to deserialize MessagePack data"}),
-        };
+        if raw {
+            results.push(json!({
+                "key": item.key,
+                "value": general_purpose::STANDARD.encode(&item.value)
+            }));
+        } else {
+            // deserialize messagepack into serde_json::Value
+            let value = match from_read_ref::<_, Value>(&item.value) {
+                Ok(value) => value,
+                Err(_) => json!({"error": "Failed to deserialize MessagePack data"}),
+            };
 
-        results.push(json!({
-            "key": item.key,
-            "value": value
-        }));
+            results.push(json!({
+                "key": item.key,
+                "value": value
+            }));
+        }
     }
 
     // serialize results as json and return!
@@ -117,18 +130,44 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .author("Sr. Rust Developer")
         .arg_required_else_help(true)
         .subcommand_required(true)
-        .subcommand(Command::new("get")
-            .about("gets a value for a key")
-            .arg(Arg::new("key").required(true)))
-        .subcommand(Command::new("set")
-            .about("sets a value for a key with optional ttl")
-            .arg(Arg::new("key").required(true))
-            .arg(Arg::new("value").required(true))
-            .arg(Arg::new("ttl").required(false).value_parser(clap::value_parser!(i64))))
-        .subcommand(Command::new("query")
-            .about("queries a key with optional history count")
-            .arg(Arg::new("key").required(true))
-            .arg(Arg::new("history_count").required(false).value_parser(clap::value_parser!(i64))))
+        .subcommand(
+            Command::new("get")
+                .about("gets a value for a key")
+                .arg(Arg::new("key").required(true))
+                .arg(
+                    Arg::new("raw")
+                        .long("raw")
+                        .action(ArgAction::SetTrue)
+                        .help("returns raw data"),
+                ),
+        )
+        .subcommand(
+            Command::new("set")
+                .about("sets a value for a key with optional ttl")
+                .arg(Arg::new("key").required(true))
+                .arg(Arg::new("value").required(true))
+                .arg(
+                    Arg::new("ttl")
+                        .required(false)
+                        .value_parser(clap::value_parser!(i64)),
+                ),
+        )
+        .subcommand(
+            Command::new("query")
+                .about("queries a key with optional history count")
+                .arg(Arg::new("key").required(true))
+                .arg(
+                    Arg::new("history_count")
+                        .required(false)
+                        .value_parser(clap::value_parser!(i64)),
+                )
+                .arg(
+                    Arg::new("raw")
+                        .long("raw")
+                        .action(ArgAction::SetTrue)
+                        .help("returns raw data"),
+                ),
+        )
         .get_matches();
 
     // Retrieve host and port from environment or use default values
@@ -141,22 +180,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cmd.subcommand() {
         Some(("get", sub_matches)) => {
             let key = sub_matches.get_one::<String>("key").unwrap();
-            get(&mut client, key.to_string()).await?;
-        },
+            let raw = sub_matches.get_flag("raw");
+
+            get(&mut client, key.to_string(), raw).await?;
+        }
         Some(("set", sub_matches)) => {
             let key = sub_matches.get_one::<String>("key").unwrap();
-            let value = sub_matches.get_one::<String>("value").unwrap().as_bytes().to_vec();
-            let ttl = sub_matches.get_one::<String>("ttl")
-                        .and_then(|v| v.parse::<i64>().ok())
-                        .unwrap_or(0);
+            let value = sub_matches
+                .get_one::<String>("value")
+                .unwrap()
+                .as_bytes()
+                .to_vec();
+            let ttl = sub_matches
+                .get_one::<String>("ttl")
+                .and_then(|v| v.parse::<i64>().ok())
+                .unwrap_or(0);
             set(&mut client, key.to_string(), value, ttl).await?;
-        },
+        }
         Some(("query", sub_matches)) => {
             let key = sub_matches.get_one::<String>("key").unwrap();
-            let history_count = sub_matches.get_one::<String>("history_count")
-                                  .and_then(|v| v.parse::<i64>().ok());
-            query(&mut client, key.to_string(), history_count).await?;
-        },
+            let history_count = sub_matches
+                .get_one::<String>("history_count")
+                .and_then(|v| v.parse::<i64>().ok());
+            let raw = sub_matches.get_flag("raw");
+
+            query(&mut client, key.to_string(), history_count, raw).await?;
+        }
         _ => unreachable!(),
     }
 

--- a/src/datastore/mod.rs
+++ b/src/datastore/mod.rs
@@ -4,10 +4,11 @@ use std::sync::{atomic::AtomicI64, Arc};
 use std::time::SystemTime;
 use tokio::sync::{Mutex, Notify};
 
-use crate::nestedmap::options::SetOptions;
-use crate::nestedmap::{Item, NestedMap};
-
+use crate::nestedmap::options::{GetOptions, SetOptions};
+use crate::nestedmap::NestedMap;
 use expiration::ExpirationEntry;
+
+pub use crate::nestedmap::Item;
 
 pub mod expiration;
 
@@ -61,6 +62,11 @@ impl Datastore {
     pub async fn get(&self, key: &str) -> Option<Item> {
         let map = self.map.lock().await;
         map.get(key).cloned()
+    }
+
+    pub async fn query(&self, key: &str, options: Option<GetOptions>) -> Vec<Item> {
+        let map = self.map.lock().await;
+        map.query(key, options)
     }
 }
 


### PR DESCRIPTION
This PR implements the following additional features:

* Allow the client to override the server:port with env `REMOTE_HOST` and `REMOTE_PORT` (#9)
* Integrate clap with initial command and argument structure
* Implement `query` in the Datastore 
* Optional `--raw` argument added to `get` and `query` for cases where you want the raw data

#### server:port
```
$ REMOTE_HOST=127.0.0.1 REMOTE_PORT=7778 ./client get yo.yo
Error: tonic::transport::Error(Transport, hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 61, kind: ConnectionRefused, message: "Connection refused" })))
$ REMOTE_PORT=7778 ./target/debug/client query "image.>" --raw
[{"key":"image.net....
```

#### clap
```
$ ./client
Usage: client <COMMAND>

Commands:
  get    gets a value for a key
  set    sets a value for a key with optional ttl
  query  queries a key with optional history count
  help   Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

#### Query
```
$ ./client set "a.b" hi
$ ./client set "a.b.c" bye
$ ./client query "a.>" --raw | jq '.[] | .value |= @base64d'
{
  "key": "a.b",
  "value": "aGk="
}
{
  "key": "a.b.c",
  "value": "Ynll"
}
```
---
Needs tests!